### PR TITLE
only fetch new notifications

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,14 +116,13 @@ func getNotifications(client *github.Client, username string, page, perPage int)
 			PerPage: perPage,
 		},
 	}
-	if lastChecked.IsZero() {
-		lastChecked = time.Now()
-	}
 
 	notifications, resp, err := client.Activity.ListNotifications(opt)
 	if err != nil {
 		return err
 	}
+
+	lastChecked = time.Now()
 
 	for _, notification := range notifications {
 		// handle event


### PR DESCRIPTION
ghb0t is working great, but it keeps removing the same branches

I think this is because lastChecked is only set once to time.Now()

if that's it, this patch might fix it

it still tries to delete already removed branches on the start (because lastChecked is zero) but I think that's fine
now I'm waiting for my next PR to be merged to test it
