### PR TITLE
Add the packaging metadata to build the ghb0t snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ghb0t
+version: master
+summary: delete your github fork's branches after a pull request has been merged
+description: |
+  GitHub Bot to automatically delete your fork's branches after a pull request
+  has been merged.
+  NOTE: This will never delete a branch named "master" AND will never delete a
+  branch that is not owned by the current authenticated user. If the pull
+  request is closed without merging, it will not delete it.
+
+grade: devel
+confinement: strict
+
+apps:
+  ghb0t:
+    command: ghb0t
+    plugs: [network]
+
+parts:
+  ghb0t:
+    source: .
+    plugin: go
+    go-importpath: github.com/jessfraz/ghb0t


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.