### PR TITLE
Don't delete the default branch

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,8 +182,9 @@ func handleNotification(ctx context.Context, client *github.Client, notification
 				return nil
 			}
 			owner := *pr.Head.Repo.Owner.Login
-			// Never delete the master branch or a branch we do not own.
-			if owner == username && branch != "master" {
+			defaultBranch := *notification.Repository.DefaultBranch
+			// Never delete the default branch or a branch we do not own.
+			if owner == username && branch != defaultBranch {
 				_, err := client.Git.DeleteRef(ctx, username, *pr.Head.Repo.Name, strings.Replace("heads/"+*pr.Head.Ref, "#", "%23", -1))
 				// 422 is the error code for when the branch does not exist.
 				if err != nil && !strings.Contains(err.Error(), " 422 ") {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: delete your github fork's branches after a pull request has been merged
 description: |
   GitHub Bot to automatically delete your fork's branches after a pull request
   has been merged.
-  NOTE: This will never delete a branch named "master" AND will never delete a
+  NOTE: This will never delete the default branch AND will never delete a
   branch that is not owned by the current authenticated user. If the pull
   request is closed without merging, it will not delete it.
 


### PR DESCRIPTION
Not everyone uses `master` as the default branch so instead of guarding
against deleting `master`, we can instead guard
`Repository.DefaultBranch` which will handle what ever the project has
defined as their mainline.

Closes #7